### PR TITLE
Use system encoding to show console output

### DIFF
--- a/lib/console.tcl
+++ b/lib/console.tcl
@@ -97,7 +97,7 @@ method exec {cmd {after {}}} {
 		lappend cmd 2>@1
 		set fd_f [_open_stdout_stderr $cmd]
 	}
-	fconfigure $fd_f -blocking 0 -translation binary
+	fconfigure $fd_f -blocking 0 -translation binary -encoding [encoding system]
 	fileevent $fd_f readable [cb _read $fd_f $after]
 }
 


### PR DESCRIPTION
This patch fixes issue https://github.com/prati0100/git-gui/issues/68

I used `gui.encoding` as console encoding, but it can be better to introduce new option eg `gui.console-encoding` for it.