### PR TITLE
advisory leftovers

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -638,8 +638,6 @@ proc _lappend_nice {cmd_var} {
 		set _nice [_which nice]
 		if {[catch {safe_exec [list $_nice git version]}]} {
 			set _nice {}
-		} elseif {[is_Windows] && [file dirname $_nice] ne [file dirname $::_git]} {
-			set _nice {}
 		}
 	}
 	if {$_nice ne {}} {

--- a/git-gui.sh
+++ b/git-gui.sh
@@ -87,12 +87,6 @@ if {[is_Windows]} {
 	set _search_exe {}
 }
 
-if {[is_Windows]} {
-	set gitguidir [file dirname [info script]]
-	regsub -all ";" $gitguidir "\\;" gitguidir
-	set env(PATH) "$gitguidir;$env(PATH)"
-}
-
 set _search_path {}
 set _path_seen [dict create]
 foreach p [split $env(PATH) $_path_sep] {

--- a/lib/shortcut.tcl
+++ b/lib/shortcut.tcl
@@ -3,26 +3,37 @@
 
 proc do_windows_shortcut {} {
 	global _gitworktree
-	set fn [tk_getSaveFile \
-		-parent . \
-		-title [mc "%s (%s): Create Desktop Icon" [appname] [reponame]] \
-		-initialfile "Git [reponame].lnk"]
-	if {$fn != {}} {
-		if {[file extension $fn] ne {.lnk}} {
-			set fn ${fn}.lnk
+
+	set desktop [safe_exec [list cygpath -mD]]
+	set link_file "Git [reponame].lnk"
+	set link_path [file normalize [file join $desktop $link_file]]
+
+	# on Windows, tk_getSaveFile dereferences .lnk files, so no simple
+	# filename chooser is available. Use the default or quit.
+	if {[file exists $link_path]} {
+		set answer [tk_messageBox \
+			-type yesno \
+			-title [mc "%s (%s): Create Desktop Icon" [appname] [reponame]] \
+			-default yes \
+			-message [mc "Replace existing shortcut: %s?" $link_file]]
+		if {$answer == no} {
+			return
 		}
-		# Use git-gui.exe if available (ie: git-for-windows)
-		set cmdLine [list [_which git-gui]]
-		if {$cmdLine eq {}} {
-			set cmdLine [list [info nameofexecutable] \
-							 [file normalize $::argv0]]
-		}
-		if {[catch {
-				win32_create_lnk $fn $cmdLine \
-					[file normalize $_gitworktree]
-			} err]} {
-			error_popup [strcat [mc "Cannot write shortcut:"] "\n\n$err"]
-		}
+	}
+
+	# Use git-gui.exe if found, fall back to wish + launcher
+	set link_arguments {}
+	set link_target [_which git-gui]
+	if {![file executable $link_target]} {
+		set link_target [file normalize [info nameofexecutable]]
+		set link_arguments [file normalize $::argv0]
+	}
+	set cmdLine [list $link_target $link_arguments]
+	if {[catch {
+		win32_create_lnk $link_path $cmdLine \
+			[file normalize $_gitworktree]
+	} err]} {
+		error_popup [strcat [mc "Cannot write shortcut:"] "\n\n$err"]
 	}
 }
 

--- a/lib/shortcut.tcl
+++ b/lib/shortcut.tcl
@@ -23,7 +23,10 @@ proc do_windows_shortcut {} {
 
 	# Use git-gui.exe if found, fall back to wish + launcher
 	set link_arguments {}
-	set link_target [_which git-gui]
+	set link_target [safe_exec [list cygpath -m /cmd/git-gui.exe]]
+	if {![file executable $link_target]} {
+		set link_target [_which git-gui]
+	}
 	if {![file executable $link_target]} {
 		set link_target [file normalize [info nameofexecutable]]
 		set link_arguments [file normalize $::argv0]

--- a/windows/git-gui.sh
+++ b/windows/git-gui.sh
@@ -13,13 +13,5 @@ if { $argc >=2 && [lindex $argv 0] == "--working-dir" } {
 	incr argc -2
 }
 
-set basedir [file dirname \
-            [file dirname \
-             [file dirname [info script]]]]
-set bindir [file join $basedir bin]
-set bindir "$bindir;[file join $basedir mingw bin]"
-regsub -all ";" $bindir "\\;" bindir
-set env(PATH) "$bindir;$env(PATH)"
-unset bindir
-
-source [file join [file dirname [info script]] git-gui.tcl]
+set thisdir [file normalize [file dirname [info script]]]
+source [file join $thisdir git-gui.tcl]


### PR DESCRIPTION
This branch has 5 commits carrying changes identified when creating the recent advisory, but deemed out of scope for that effort. These address issues on Windows only.