### PR TITLE
Slight adjustment to the interface

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -3336,10 +3336,10 @@ ttk::scrollbar .vpane.lower.commarea.buffer.frame.sby \
 
 pack .vpane.lower.commarea.buffer.frame.sbx -side bottom -fill x
 pack .vpane.lower.commarea.buffer.frame.sby -side right -fill y
-pack $ui_comm -side left -fill y
+pack $ui_comm -side left -fill both -expand 1
 pack .vpane.lower.commarea.buffer.header -side top -fill x
-pack .vpane.lower.commarea.buffer.frame -side left -fill y
-pack .vpane.lower.commarea.buffer -side left -fill y
+pack .vpane.lower.commarea.buffer.frame -side left -fill both -expand 1
+pack .vpane.lower.commarea.buffer -side left -fill both -expand 1
 
 # -- Commit Message Buffer Context Menu
 #


### PR DESCRIPTION
Make the the following tk widgets take all available horizontal space within their parent and expand with the application window:
- .vpane.lower.commarea.buffer
- .vpane.lower.commarea.buffer.frame
- .vpane.lower.commarea.buffer.frame.t (via ui_comm variable)

This allows the commit message editor along with its widgets reflow This is visually better on very wide monitors plus it is the same behavior as the widget above